### PR TITLE
Problem with input field, maxlength attribute and long placeholder text

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -50,6 +50,7 @@
         ATTR_EVENTS_BOUND = "data-placeholder-bound",
         ATTR_OPTION_FOCUS = "data-placeholder-focus",
         ATTR_OPTION_LIVE = "data-placeholder-live",
+        ATTR_MAXLENGTH = "data-placeholder-maxlength",
 
         // Various other variables used throughout the rest of the script
         test = document.createElement("input"),
@@ -73,6 +74,13 @@
             elem.value = elem.value.replace(elem.getAttribute(ATTR_CURRENT_VAL), "");
             elem.className = elem.className.replace(classNameRegExp, "");
 
+            // Restore the maxlength value
+            var maxLength = elem.getAttribute(ATTR_MAXLENGTH);
+            if (maxLength) {
+                elem.setAttribute("maxLength", maxLength);
+                elem.removeAttribute(ATTR_MAXLENGTH);
+            }
+
             // If the polyfill has changed the type of the element we need to change it back
             type = elem.getAttribute(ATTR_INPUT_TYPE);
             if (type) {
@@ -91,6 +99,13 @@
             elem.setAttribute(ATTR_ACTIVE, "true");
             elem.value = val;
             elem.className += " " + placeholderClassName;
+
+            // Store and remove the maxlength value
+            var maxLength = elem.getAttribute(ATTR_MAXLENGTH);
+            if (!maxLength) {
+                elem.setAttribute(ATTR_MAXLENGTH, elem.maxLength);
+                elem.removeAttribute("maxLength");
+            }
 
             // If the type of element needs to change, change it (e.g. password inputs)
             type = elem.getAttribute(ATTR_INPUT_TYPE);


### PR DESCRIPTION
The current code causes a problem when the input field has a maxlength attribute and the placeholder text is longer than that length. The current pull request solves this by clearing (and storing) the maxlength value when the placeholder is shown and restoring it when the placeholder should be hidden.

While achieving this, I also removed code duplication in `makeKeyupHandler`.
