### PR TITLE
Don't show placeholder if element is already focussed

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -252,8 +252,10 @@
         elem.setAttribute(ATTR_EVENTS_BOUND, "true");
         elem.setAttribute(ATTR_CURRENT_VAL, placeholder);
 
-        // If the element doesn't have a value, set it to the placeholder string
-        showPlaceholder(elem);
+        // If the element doesn't have a value and is not focussed, set it to the placeholder string
+        if (hideOnInput || elem !== document.activeElement) {
+            showPlaceholder(elem);
+        }
     }
 
     Placeholders.nativeSupport = test.placeholder !== void 0;


### PR DESCRIPTION
when live-adding placeholders
