### PR TITLE
Add link to the Placeholder.js gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Placeholders.js is licensed under the [MIT License](http://en.wikipedia.org/wiki
 ## Get it!
 
 Download the polyfill and get a whole load of information and instructions at [our new website](http://jamesallardice.github.com/Placeholders.js/).
+If you're using Ruby on Rails, you can also try out [our gem](https://github.com/ets-berkeley-edu/placeholder-gem).
     
 ##Supported Browsers
 


### PR DESCRIPTION
For our project we needed to wrap up the JavaScript file into a gem.
Feel free to try it https://github.com/ets-berkeley-edu/placeholder-gem
