### PR TITLE
Avoid IE9 activeElement of death

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -63,6 +63,16 @@
     // No-op (used in place of public methods when native support is detected)
     function noop() {}
 
+    // Avoid IE9 activeElement of death when an iframe is used.
+    // More info:
+    // http://bugs.jquery.com/ticket/13393
+    // https://github.com/jquery/jquery/commit/85fc5878b3c6af73f42d61eedf73013e7faae408
+    function safeActiveElement() {
+        try {
+            return document.activeElement;
+        } catch ( err ) { }
+    }
+
     // Hide the placeholder value on a single element. Returns true if the placeholder was hidden and false if it was not (because it wasn't visible in the first place)
     function hidePlaceholder(elem, keydownValue) {
         var type,
@@ -208,7 +218,7 @@
     }
     function makeClickHandler(elem) {
         return function () {
-            if (elem === document.activeElement && elem.value === elem.getAttribute(ATTR_CURRENT_VAL) && elem.getAttribute(ATTR_ACTIVE) === "true") {
+            if (elem === safeActiveElement() && elem.value === elem.getAttribute(ATTR_CURRENT_VAL) && elem.getAttribute(ATTR_ACTIVE) === "true") {
                 Utils.moveCaret(elem, 0);
             }
         };
@@ -253,7 +263,7 @@
         elem.setAttribute(ATTR_CURRENT_VAL, placeholder);
 
         // If the element doesn't have a value and is not focussed, set it to the placeholder string
-        if (hideOnInput || elem !== document.activeElement) {
+        if (hideOnInput || elem !== safeActiveElement()) {
             showPlaceholder(elem);
         }
     }


### PR DESCRIPTION
I was testing this polyfill on IE9 and noticed that IE was throwing  "SCRIPT16389: Unspecified error". This only happened when I used an iframe to load the page that had the polyfill in use.

Turns out that the error gets thrown if `document.activeElement` is asked inside an iframe while the page is loading. jQuery already fixed this, so I use the same fix for placeholders.js and after that the page started working normally.

More info:
http://bugs.jquery.com/ticket/13393
https://github.com/jquery/jquery/commit/85fc5878b3c6af73f42d61eedf73013e7faae408
