### PR TITLE
Fix the bug where reloading the page will turn the placeholder text into actual value of the filed

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -351,9 +351,10 @@
         }, 100);
     }
 
-    window.onbeforeunload = function() {
+    Utils.addEventListener(window, 'beforeunload', function() {
       Placeholders.disable();
-    }
+    });
+
     // Expose public methods
     Placeholders.disable = Placeholders.nativeSupport ? noop : disablePlaceholders;
     Placeholders.enable = Placeholders.nativeSupport ? noop : enablePlaceholders;


### PR DESCRIPTION
### Description

When doing page reloading (Ctrl+R in IE8, for example), since in https://github.com/jamesallardice/Placeholders.js/blob/master/lib/main.js#L102 the element value is set and not cleared during the reloading. So the second time https://github.com/jamesallardice/Placeholders.js/blob/master/lib/main.js#L100 will evaluate to false, thus no placeholder is rendered. Instead, the input will have the placeholder value as the actual value. This commit fixes that.
