### PR TITLE
Fix $.fn.val issue on IE9

### DIFF
--- a/lib/adapters/placeholders.jquery.js
+++ b/lib/adapters/placeholders.jquery.js
@@ -7,10 +7,12 @@
 
     if (!Placeholders.nativeSupport) {
         $.fn.val = function (val) {
-            if (val === undefined && this.eq(0).data("placeholder-active")) {
-                return "";
-            }
-            return originalValFn.apply(this, arguments);
+          var originalValue = originalValFn.apply(this, arguments);
+          var placeholder = this.eq(0).data("placeholder-value");
+          if (val === undefined && this.eq(0).data("placeholder-active") && originalValue == placeholder) {
+            return "";
+          }
+          return originalValue;
         };
 
         $.fn.prop = function (name, val) {


### PR DESCRIPTION
This is an issue with the jquery.adapter on IE9 when Placeholders#enable is used, like after an ajax submission.

Basically, when a form is refreshed because of an ajax response, the placeholders are gone in IE9. So we need to call Placeholders#enable. When doing that, $.fn.val() returns an empty string value for the fields that were blank before the submission, even if we change the contents later.

This commit is a workaround that fixes the issue.
