### PR TITLE
Fix error on beforeunload in browsers with native support

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -362,7 +362,7 @@
     }
 
     Utils.addEventListener(global, "beforeunload", function () {
-        disablePlaceholders();
+        Placeholders.disable();
     });
 
     // Expose public methods


### PR DESCRIPTION
This commit updates the `beforeunload` event handler to call the
`disable` function instead of `disablePlaceholders` to take advantage
of the condition that checks for native support. Otherwise, in
`handleElem`, the for loop would raise an error because `handleInputs`
would be undefined.
