### PR TITLE
Mess with maxlength only if specified

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -86,10 +86,12 @@
             elem.className = elem.className.replace(classNameRegExp, "");
 
             // Restore the maxlength value
-            maxLength = elem.getAttribute(ATTR_MAXLENGTH);
-            if (maxLength) {
-                elem.setAttribute("maxLength", maxLength);
-                elem.removeAttribute(ATTR_MAXLENGTH);
+            if (elem.hasAttribute(ATTR_MAXLENGTH)) {
+                maxLength = elem.getAttribute(ATTR_MAXLENGTH);
+                if (maxLength > 0) {
+                    elem.setAttribute("maxLength", maxLength);
+                    elem.removeAttribute(ATTR_MAXLENGTH);
+                }
             }
 
             // If the polyfill has changed the type of the element we need to change it back
@@ -113,10 +115,12 @@
             elem.className += " " + placeholderClassName;
 
             // Store and remove the maxlength value
-            maxLength = elem.getAttribute(ATTR_MAXLENGTH);
-            if (!maxLength) {
-                elem.setAttribute(ATTR_MAXLENGTH, elem.maxLength);
-                elem.removeAttribute("maxLength");
+            if (elem.hasAttribute("maxLength")) {
+                maxLength = elem.getAttribute("maxLength") || elem.maxLength;
+                if (parseInt(maxLength, 10) > 0) {
+                    elem.setAttribute(ATTR_MAXLENGTH, maxLength);
+                    elem.removeAttribute("maxLength");
+                }
             }
 
             // If the type of element needs to change, change it (e.g. password inputs)


### PR DESCRIPTION
It seems the previous patch was causing problems in Firefox 3.6 since it
was returning -1 for the value of the maxlength attribute if the
attribute was never supplied in the first place.

This patch tries to detect if the maxlength was supplied, and only
proceeds to manipulate it if it is present.

**Note**: Unfortunately, I had no time to test this change in an actual browser. Please, please, test it in IE8 and Firefox 3.6 before merging. Thanks and sorry for the extra work.
