### PR TITLE
Fix for  handleinputs and handletextareas being null

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -146,9 +146,12 @@
             handleInputs = node ? node.getElementsByTagName("input") : inputs;
             handleTextareas = node ? node.getElementsByTagName("textarea") : textareas;
 
+            var handleInputsLength = handleInputs ? handleInputs.length : 0;
+            var handleTextAreasLength = handleTextareas ? handleTextareas.length : 0;
+
             // Run the callback for each element
-            for (i = 0, len = handleInputs.length + handleTextareas.length; i < len; i++) {
-                elem = i < handleInputs.length ? handleInputs[i] : handleTextareas[i - handleInputs.length];
+            for (i = 0, len = handleInputsLength + handleTextAreasLength; i < len; i++) {
+                elem = i < handleInputsLength ? handleInputs[i] : handleTextareas[i - handleInputsLength];
                 callback(elem);
             }
         }


### PR DESCRIPTION
In IE, if handleInputs or handleTextAreas is undefined, a undefined error was being thrown on length. This checks that the item has a value before trying to use it
