### PR TITLE
Prevent JS error in IE when the form attribute is used on an input

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -243,6 +243,11 @@
         if (elem.form) {
             form = elem.form;
 
+            // If the type of the property is a string then we have a "form" attribute and need to get the real form
+            if (typeof form === "string") {
+                form = document.getElementById(form);
+            }
+
             // Set a flag on the form so we know it's been handled (forms can contain multiple inputs)
             if (!form.getAttribute(ATTR_FORM_HANDLED)) {
                 Utils.addEventListener(form, "submit", makeSubmitHandler(form));

--- a/test/default/tests.html
+++ b/test/default/tests.html
@@ -53,6 +53,11 @@
             <button type="submit">Submit form</button>
         </form>
 
+        <!-- Polyfill should handle input elements that specify their form with an attribute -->
+        <form method="get" action="" id="form2">
+            <input type="text" form="form2" placeholder="Test form attribute">
+        </form>
+
         <script src="../../build/Placeholders.js"></script>
         <script src="tests.js"></script>
     </body>


### PR DESCRIPTION
In IE if the `form` attribute is present on an `input` element, the `form` property returns the value of the attribute (which should be the ID of a form element in the same document). This PR prevents a JS error that was thrown because we were assuming the value of `element.form` was always `null` or a DOM element.
