### PR TITLE
Remove password from valid types

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -8,7 +8,6 @@
             "url",
             "tel",
             "email",
-            "password",
             "number",
             "textarea"
         ],


### PR DESCRIPTION
If the browser doesn't support placeholder attribute, Placeholder.js, change the value of input to the value of the placeholder attribute. Since password input doesn't show the value and instead show asterisks, this seems as a not pleasant behaviour.
