### PR TITLE
Only add beforeunload event listener when needed

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -367,11 +367,11 @@
                 clearInterval(timer);
             }
         }, 100);
-    }
 
-    Utils.addEventListener(global, "beforeunload", function () {
-        Placeholders.disable();
-    });
+        Utils.addEventListener(global, "beforeunload", function () {
+            Placeholders.disable();
+        });
+    }
 
     // Expose public methods
     Placeholders.disable = Placeholders.nativeSupport ? noop : disablePlaceholders;


### PR DESCRIPTION
Currently Placeholders.js unconditionally adds a listener to the
beforeunload event. Unfortunately, this prevents "Back-Forward
Cache"/"Page Cache"/"Fast History Navigation" on Firefox/Safari/Opera
respectively.

Since Placeholders.disable is a no-op when browsers have native support
for placeholders, the beforeunload event is only required on browsers
lacking native support.  This commit only adds it on those browsers.

Note:  It's not clear to me why disabling the placeholders when
unloading the page is useful, so it may be worth removing altogether
based on your analysis of the tradeoffs.  However, since I am unsure,
this commit still registers it when placeholders are not natively
supported.

Signed-off-by: Kevin Locke klocke@quantpost.com
