### PR TITLE
Add CommonJS and spm support

### DIFF
--- a/.spmignore
+++ b/.spmignore
@@ -1,0 +1,2 @@
+test
+lib

--- a/.spmignore
+++ b/.spmignore
@@ -1,2 +1,3 @@
 test
 lib
+node_modules

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -74,7 +74,8 @@ module.exports = function (grunt) {
             basic: {
                 src: [
                     "lib/utils.js",
-                    "lib/main.js"
+                    "lib/main.js",
+                    "lib/exports.js"
                 ],
                 dest: "build/placeholders.js"
             },

--- a/lib/exports.js
+++ b/lib/exports.js
@@ -1,0 +1,14 @@
+/* CommonJS */
+if (typeof exports == 'object') {
+    module.exports = Placeholders;
+}
+/* AMD module */
+else if (typeof define == 'function' && define.amd) {
+    define(function() {
+        return Placeholders;
+    });
+}
+/* Browser global */
+else {
+    this.Placeholders = Placeholders;
+}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "Placeholders.js",
+    "name": "placeholders.js",
     "version": "3.0.2",
     "author": "James Allardice <admin@jamesallardice.com>",
     "description": "A JavaScript polyfill for the HTML5 placeholder attribute",

--- a/package.json
+++ b/package.json
@@ -3,11 +3,13 @@
     "version": "3.0.2",
     "author": "James Allardice <admin@jamesallardice.com>",
     "description": "A JavaScript polyfill for the HTML5 placeholder attribute",
-    "private": true,
     "devDependencies": {
         "grunt": "0.4.x",
         "grunt-contrib-jshint": "0.3.x",
         "grunt-contrib-concat": "0.1.x",
         "grunt-contrib-uglify": "0.2.x"
+    },
+    "spm": {
+        "main": "build/placeholders.js"
     }
 }


### PR DESCRIPTION
A nicer package manager: http://spmjs.io
Documentation: http://spmjs.io/documentation

http://spmjs.io/package/placeholders.js

---

It is a package manager based on [Sea.js](https://github.com/seajs/seajs) which is a popular module loader in China. spm package need a CommonJS source.

spmjs focus in browser side. We supply a complete lifecycle managment of package by using [spm](https://github.com/spmjs/spm/tree/master).

> If you need ownership of placeholders.js in spmjs, I can add it for your account after signing in http://spmjs.io.
