### PR TITLE
Handle int placeholders correctly with jQuery adapter

### DIFF
--- a/lib/adapters/placeholders.jquery.js
+++ b/lib/adapters/placeholders.jquery.js
@@ -10,7 +10,7 @@
         $.fn.val = function (val) {
             var originalValue = originalValFn.apply(this, arguments),
                 placeholder = this.eq(0).data("placeholder-value");
-            if (val === undefined && this.eq(0).data("placeholder-active") && originalValue === placeholder) {
+            if (val === undefined && this.eq(0).data("placeholder-active") && originalValue === "" + placeholder) {
                 return "";
             }
             return originalValue;

--- a/test/adapters/jquery/tests.html
+++ b/test/adapters/jquery/tests.html
@@ -22,6 +22,9 @@
         <!-- Adapter should handle input types that change after page load e.g. text->password -->
         <input type="text" id="handle3" placeholder="Change to password">
 
+        <!-- Adapter should handle placeholder values of integer -->
+        <input type="text" id="handle4" placeholder="1234">
+
         <script src="http://code.jquery.com/jquery-1.10.2.min.js"></script>
         <script src="../../../build/placeholders.jquery.js"></script>
         <script src="tests.js"></script>

--- a/test/adapters/jquery/tests.js
+++ b/test/adapters/jquery/tests.js
@@ -31,6 +31,9 @@ setTimeout(function () {
         alert($("#handle3").val() === "");
         alert($("#handle3").prop("value") === "");
 
+        alert($("#handle4").val() === "");
+        alert($("#handle4").prop("value") === "");
+
         // The behaviour of `val` and `prop` as setters should not be affected)
         alert($("#jq1").val("set new") instanceof $);
         alert($("#handle3").prop("value", "another new") instanceof $);


### PR DESCRIPTION
if int value is specified in a placeholder,
`$(elem).val()` returns a string value, but `$(elem).data("placeholder-value")` returns a int value.
