### PR TITLE
replaced elem.blur event on makeKeyupHandler to remove uncessary trig…

### DIFF
--- a/lib/placeholders.js
+++ b/lib/placeholders.js
@@ -489,7 +489,9 @@
 
       // If the element is now empty we need to show the placeholder
       if ( elem.value === '' ) {
-        elem.blur();
+        showPlaceholder(elem);
+	//Removing uneccessary triggering of the blur event on keyup
+	//elem.blur();
         moveCaret(elem, 0);
       }
     };


### PR DESCRIPTION
Instead of triggering the blur event which the user might have another event handling, call showPlaceholder instead since makeBlurHandler does only that.
