### PR TITLE
Fix #75 - Bug with form submit handler not being attached in some cases

### DIFF
--- a/lib/placeholders.js
+++ b/lib/placeholders.js
@@ -513,11 +513,16 @@
 
     // If the element is part of a form, make sure the placeholder string is
     // not submitted as a value.
+    //
+    // 'form' property may be the containing HTMLFormElement
+    // or the id of any form within the same document (string)
     var form = elem.form;
-    if ( form && typeof form === 'string' ) {
+    if ( form ) {
 
-      // Get the real form.
-      form = document.getElementById(form);
+      if ( typeof form === 'string' ) {
+        // Get the real form.
+        form = document.getElementById(form);
+      }
 
       // Set a flag on the form so we know it's been handled (forms can contain
       // multiple inputs).


### PR DESCRIPTION
According to [MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement), the `form` property of an HTMLInputElement may be the id of any form in the current document **or** the containing form HTMLFormElement itself.

The second case was previously not accounted for, only adding the submit handler when a string was present. This was breaking functionality on IE9.

All credit for this goes to @littletijn: http://git.io/vRYQX only submitting this myself as they have not responded to the issue, and (s)he doesn't look to be active.

Fixes #75 
