### PR TITLE
get the link working on npm.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "Placeholders.js",
+  "name": "placeholders.js",
   "version": "4.0.1",
   "author": "James Allardice <admin@jamesallardice.com>",
   "description": "A JavaScript polyfill for the HTML5 placeholder attribute",


### PR DESCRIPTION
think its a case-sensitive issue: https://github.com/jamesallardice/Placeholders.js/issues/90
