### PR TITLE
Fixed when password field is selected on page load.

### DIFF
--- a/lib/placeholders.js
+++ b/lib/placeholders.js
@@ -208,7 +208,7 @@
             if (
               elem.type === 'password' &&
               !elem.getAttribute(ATTR_INPUT_TYPE) &&
-              changeType(elem, 'text')
+              changeType(elem, 'password')
             ) {
               elem.setAttribute(ATTR_INPUT_TYPE, 'password');
             }


### PR DESCRIPTION
When the timer reload, password field should not be set to "text".  To reproduce the problem, autofocus a password field on page load in IE9.