### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Placeholders.js - An HTML5 placeholder attribute polyfill
+# Placeholders.js - An HTML5 placeholder attribute polyfill
 
 Placeholders.js is a polyfill (or shim, or whatever you like to call it) for
 the HTML5 placeholder attribute, as defined in the [HTML5 specification][spec].


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
